### PR TITLE
Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
   - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7
+  - DJANGO=1.8
+  - DJANGO=1.9
 install:
   - pip install --timeout=30 -q Django==$DJANGO
   - pip install --timeout=30 pep8

--- a/django_secureform/forms/__init__.py
+++ b/django_secureform/forms/__init__.py
@@ -5,7 +5,6 @@ import string
 from Crypto.Random import random
 from Crypto.Cipher import Blowfish
 
-import django
 from django import forms
 from django.conf import settings
 from django.core.cache import cache

--- a/django_secureform/forms/__init__.py
+++ b/django_secureform/forms/__init__.py
@@ -5,11 +5,17 @@ import string
 from Crypto.Random import random
 from Crypto.Cipher import Blowfish
 
+import django
 from django import forms
 from django.conf import settings
 from django.core.cache import cache
 from django.forms import widgets
-from django.forms.util import ErrorDict
+
+if django.VERSION < (1, 7):
+    from django.forms.util import ErrorDict
+else:
+    from django.forms.util import ErrorDict
+
 from django.forms.forms import pretty_name
 from django.forms.forms import NON_FIELD_ERRORS
 from django.forms.forms import BoundField

--- a/django_secureform/forms/__init__.py
+++ b/django_secureform/forms/__init__.py
@@ -10,17 +10,17 @@ from django.conf import settings
 from django.core.cache import cache
 from django.forms import widgets
 
-if django.VERSION < (1, 7):
-    from django.forms.util import ErrorDict
-else:
-    from django.forms.util import ErrorDict
-
 from django.forms.forms import pretty_name
 from django.forms.forms import NON_FIELD_ERRORS
 from django.forms.forms import BoundField
 from django.forms.forms import DeclarativeFieldsMetaclass
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
+
+if django.VERSION < (1, 7):
+    from django.forms.util import ErrorDict
+else:
+    from django.forms.utils import ErrorDict
 
 try:
     # Django <= 1.6 backwards compatibility


### PR DESCRIPTION
Fixes deprecation of `django.forms.util` for Django >= 1.7